### PR TITLE
Guard xcodebuild for CLT-only machines

### DIFF
--- a/scripts/homebrew.zsh
+++ b/scripts/homebrew.zsh
@@ -14,5 +14,8 @@ brew update
 
 echo "› \033[00;34mbrew bundle\033[0m"
 brew bundle --file $DOTFILES/apps/homebrew/Brewfile --mas
-echo "› \033[00;34msudo xcodebuild -runFirstLaunch\033[0m"
-sudo xcodebuild -runFirstLaunch
+# Only run Xcode first-launch setup if full Xcode.app is installed
+if command -v xcodebuild &>/dev/null && [[ -d "/Applications/Xcode.app" ]]; then
+    echo "› \033[00;34msudo xcodebuild -runFirstLaunch\033[0m"
+    sudo xcodebuild -runFirstLaunch
+fi


### PR DESCRIPTION
## Summary

`scripts/homebrew.zsh` unconditionally runs `sudo xcodebuild -runFirstLaunch` after brew bundle. This fails on machines with only Command Line Tools installed (no Xcode.app) with:

```
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory is a command line tools instance
```

Now only runs when full Xcode.app is present.

## Test plan
- [ ] Run `dot` on a machine with only CLT (no Xcode.app) - no xcodebuild error
- [ ] Run `dot` on a machine with Xcode.app - first-launch setup still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)