### PR TITLE
Stop hook: scope linters to changed files, cap output size

### DIFF
--- a/apps/claude/hooks/smoke-test-hook.sh
+++ b/apps/claude/hooks/smoke-test-hook.sh
@@ -127,10 +127,10 @@ echo "synthetic rubocop failure" >&2
 exit 1
 EOF
   chmod +x bin/rubocop
-  echo "ok" > file.txt
+  echo "# ok" > foo.rb
   git add -A
   git commit -q -m "init"
-  echo "changed" >> file.txt
+  echo "# changed" >> foo.rb
 
   exit_code=0
   stderr_output=$(echo '{"stop_hook_active":false}' | CLAUDE_PROJECT_DIR="$rubydir" "$HOOK" 2>&1 >/dev/null) || exit_code=$?
@@ -193,7 +193,7 @@ echo '{"stop_hook_active":true}' | PATH="$shim_dir:/bin" "$HOOK" >/dev/null 2>&1
 check "loop guard via grep fallback" 0 "$exit_code"
 
 echo
-echo "Test 8: Node project with failing typecheck AND lint accumulates both errors"
+echo "Test 8: Node project with failing typecheck AND eslint accumulates both errors"
 nodedir=$(mktemp -d)
 cleanup_dirs+=("$nodedir")
 npm_shim_dir=$(mktemp -d)
@@ -211,10 +211,19 @@ if pushd "$nodedir" >/dev/null; then
   cat > package.json <<'EOF'
 { "scripts": { "typecheck": "echo ts", "lint": "echo lint" } }
 EOF
-  echo "ok" > file.txt
+  # ESLint is detected via the binary path, not the npm script — the hook
+  # calls it directly so it can pass changed-file args.
+  mkdir -p node_modules/.bin
+  cat > node_modules/.bin/eslint <<'EOF'
+#!/usr/bin/env bash
+echo "synthetic eslint failure" >&2
+exit 1
+EOF
+  chmod +x node_modules/.bin/eslint
+  echo "let x = 1" > file.ts
   git add -A
   git commit -q -m "init"
-  echo "changed" >> file.txt
+  echo "let y = 2" >> file.ts
 
   # PATH scoped to our shim dir + system basics (for git/cat/grep etc). Omits
   # /usr/local/bin etc. so any real pnpm/npm on the host doesn't leak in.
@@ -222,11 +231,170 @@ EOF
   stderr_output=$(echo '{"stop_hook_active":false}' | PATH="$npm_shim_dir:/usr/bin:/bin" CLAUDE_PROJECT_DIR="$nodedir" "$HOOK" 2>&1 >/dev/null) || exit_code=$?
   check "both npm checks trigger and fail" 2 "$exit_code"
   check_contains "stderr labelled [typecheck]" "[typecheck]" "$stderr_output"
-  check_contains "stderr labelled [lint]" "[lint]" "$stderr_output"
+  check_contains "stderr labelled [eslint]" "[eslint]" "$stderr_output"
   check_contains "stderr has --- separator (two entries)" "---" "$stderr_output"
   popd >/dev/null
 else
   echo "  ✗ pushd failed for test 8"
+  fail=$((fail+1))
+fi
+
+echo
+echo "Test 9: Ruby project with non-Ruby change skips rubocop entirely"
+rubyskipdir=$(mktemp -d)
+cleanup_dirs+=("$rubyskipdir")
+if pushd "$rubyskipdir" >/dev/null; then
+  git init -q
+  git config user.email "test@test"
+  git config user.name "test"
+  touch Gemfile
+  mkdir -p bin
+  # Fail loudly if invoked — the test asserts rubocop is NOT called when no
+  # .rb files are in the working tree change set.
+  cat > bin/rubocop <<'EOF'
+#!/usr/bin/env bash
+echo "rubocop should NOT have run" >&2
+exit 1
+EOF
+  chmod +x bin/rubocop
+  echo "ok" > README.md
+  git add -A
+  git commit -q -m "init"
+  echo "changed" >> README.md
+
+  exit_code=0
+  stderr_output=$(echo '{"stop_hook_active":false}' | CLAUDE_PROJECT_DIR="$rubyskipdir" "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+  check "non-Ruby change skips rubocop (exit 0)" 0 "$exit_code"
+  popd >/dev/null
+else
+  echo "  ✗ pushd failed for test 9"
+  fail=$((fail+1))
+fi
+
+echo
+echo "Test 10: oversize check output is truncated, not dumped whole"
+truncdir=$(mktemp -d)
+cleanup_dirs+=("$truncdir")
+if pushd "$truncdir" >/dev/null; then
+  git init -q
+  git config user.email "test@test"
+  git config user.name "test"
+  echo "ok" > file.txt
+  git add file.txt
+  git commit -q -m "init"
+
+  mkdir -p .claude
+  # Emit ~50 KiB of output — well over the 8 KiB MAX_OUTPUT_BYTES cap.
+  cat > .claude/verify.sh <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "fast" ]]; then
+  for i in $(seq 1 1000); do
+    echo "synthetic line $i: padding bytes to push past the truncation cap" >&2
+  done
+  exit 2
+fi
+exit 0
+EOF
+  chmod +x .claude/verify.sh
+
+  echo "changed" >> file.txt
+
+  exit_code=0
+  stderr_output=$(echo '{"stop_hook_active":false}' | CLAUDE_PROJECT_DIR="$truncdir" "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+  check "oversize output still exits 2" 2 "$exit_code"
+  check_contains "stderr contains truncation marker" "output truncated" "$stderr_output"
+  # Cap is 8192 chars per error block; the wrapper text ("Fast verification
+  # failed...", "---", footer) adds a few hundred more. 12288 (1.5x) is
+  # enough slack for the wrapper without letting a doubling regression slip.
+  size=${#stderr_output}
+  if (( size < 12288 )); then
+    echo "  ✓ stderr bounded (${size} chars < 12288)"
+    pass=$((pass+1))
+  else
+    echo "  ✗ stderr too large (${size} chars, expected under 12288)"
+    fail=$((fail+1))
+  fi
+  popd >/dev/null
+else
+  echo "  ✗ pushd failed for test 10"
+  fail=$((fail+1))
+fi
+
+echo
+echo "Test 11: mixed-extension change set lints only the matching files"
+mixeddir=$(mktemp -d)
+cleanup_dirs+=("$mixeddir")
+if pushd "$mixeddir" >/dev/null; then
+  git init -q
+  git config user.email "test@test"
+  git config user.name "test"
+  touch Gemfile
+  mkdir -p bin
+  # Shim records its argv to a file we can inspect after the run.
+  cat > bin/rubocop <<EOF
+#!/usr/bin/env bash
+echo "\$@" > "$mixeddir/rubocop_args"
+echo "synthetic rubocop failure" >&2
+exit 1
+EOF
+  chmod +x bin/rubocop
+  echo "# ok" > foo.rb
+  echo "ok" > README.md
+  git add -A
+  git commit -q -m "init"
+  echo "# changed" >> foo.rb
+  echo "changed" >> README.md
+
+  exit_code=0
+  stderr_output=$(echo '{"stop_hook_active":false}' | CLAUDE_PROJECT_DIR="$mixeddir" "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+  check "rubocop runs (exit 2)" 2 "$exit_code"
+  if [[ -f rubocop_args ]]; then
+    args=$(cat rubocop_args)
+    check_contains "rubocop received foo.rb" "foo.rb" "$args"
+    if echo "$args" | grep -qF "README.md"; then
+      echo "  ✗ rubocop received README.md (should not have): $args"
+      fail=$((fail+1))
+    else
+      echo "  ✓ rubocop did not receive README.md"
+      pass=$((pass+1))
+    fi
+  else
+    echo "  ✗ rubocop_args file missing — shim not invoked"
+    fail=$((fail+1))
+  fi
+  popd >/dev/null
+else
+  echo "  ✗ pushd failed for test 11"
+  fail=$((fail+1))
+fi
+
+echo
+echo "Test 12: initial-commit (no HEAD) repo still lints staged Ruby files"
+initdir=$(mktemp -d)
+cleanup_dirs+=("$initdir")
+if pushd "$initdir" >/dev/null; then
+  git init -q
+  git config user.email "test@test"
+  git config user.name "test"
+  touch Gemfile
+  mkdir -p bin
+  cat > bin/rubocop <<'EOF'
+#!/usr/bin/env bash
+echo "synthetic rubocop failure" >&2
+exit 1
+EOF
+  chmod +x bin/rubocop
+  echo "# ok" > foo.rb
+  # Stage but do NOT commit — there's no HEAD at this point.
+  git add -A
+
+  exit_code=0
+  stderr_output=$(echo '{"stop_hook_active":false}' | CLAUDE_PROJECT_DIR="$initdir" "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+  check "no-HEAD repo with staged .rb still triggers rubocop" 2 "$exit_code"
+  check_contains "stderr labelled [rubocop]" "[rubocop]" "$stderr_output"
+  popd >/dev/null
+else
+  echo "  ✗ pushd failed for test 12"
   fail=$((fail+1))
 fi
 

--- a/apps/claude/hooks/smoke-test-hook.sh
+++ b/apps/claude/hooks/smoke-test-hook.sh
@@ -284,7 +284,7 @@ if pushd "$truncdir" >/dev/null; then
   git commit -q -m "init"
 
   mkdir -p .claude
-  # Emit ~50 KiB of output — well over the 8 KiB MAX_OUTPUT_BYTES cap.
+  # Emit ~50 KiB of output — well over the 8K-char MAX_OUTPUT_CHARS cap.
   cat > .claude/verify.sh <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "fast" ]]; then
@@ -395,6 +395,38 @@ EOF
   popd >/dev/null
 else
   echo "  ✗ pushd failed for test 12"
+  fail=$((fail+1))
+fi
+
+echo
+echo "Test 13: untracked-only changes still trigger the hook"
+untrackeddir=$(mktemp -d)
+cleanup_dirs+=("$untrackeddir")
+if pushd "$untrackeddir" >/dev/null; then
+  git init -q
+  git config user.email "test@test"
+  git config user.name "test"
+  touch Gemfile
+  mkdir -p bin
+  cat > bin/rubocop <<'EOF'
+#!/usr/bin/env bash
+echo "synthetic rubocop failure" >&2
+exit 1
+EOF
+  chmod +x bin/rubocop
+  echo "ok" > existing.txt
+  git add -A
+  git commit -q -m "init"
+  # New, untracked .rb file. Nothing modified, nothing staged.
+  echo "# new" > new.rb
+
+  exit_code=0
+  stderr_output=$(echo '{"stop_hook_active":false}' | CLAUDE_PROJECT_DIR="$untrackeddir" "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+  check "untracked-only .rb still triggers rubocop" 2 "$exit_code"
+  check_contains "stderr labelled [rubocop]" "[rubocop]" "$stderr_output"
+  popd >/dev/null
+else
+  echo "  ✗ pushd failed for test 13"
   fail=$((fail+1))
 fi
 

--- a/apps/claude/hooks/verify.sh
+++ b/apps/claude/hooks/verify.sh
@@ -40,20 +40,24 @@ cd "${CLAUDE_PROJECT_DIR:-$PWD}" 2>/dev/null || {
 }
 git rev-parse --git-dir >/dev/null 2>&1 || exit 0
 
-# Nothing changed, nothing to verify
-if git diff --quiet && git diff --staged --quiet; then
+# Nothing changed, nothing to verify. Use --porcelain so untracked files
+# count too — otherwise a brand-new file on its own would short-circuit
+# the hook before changed_files() got a chance to lint it.
+if [[ -z "$(git status --porcelain 2>/dev/null)" ]]; then
   exit 0
 fi
 
 errors=()
 
-# Truncate to MAX_OUTPUT_CHARS if longer; the suffix tells the agent the
-# full length so it knows there's more behind the cap.
+# Truncate to MAX_OUTPUT_CHARS as a hard cap, including the truncation
+# suffix. We reserve space for the suffix so the final block stays within
+# the limit regardless of the source length.
 truncate_output() {
   local s="$1" len=${#1}
   if (( len > MAX_OUTPUT_CHARS )); then
-    s="${s:0:$MAX_OUTPUT_CHARS}"
-    s+=$'\n... (output truncated; full length: '"$len"' chars)'
+    local suffix=$'\n... (output truncated; full length: '"$len"' chars)'
+    local body_max=$(( MAX_OUTPUT_CHARS - ${#suffix} ))
+    s="${s:0:$body_max}$suffix"
   fi
   printf '%s' "$s"
 }

--- a/apps/claude/hooks/verify.sh
+++ b/apps/claude/hooks/verify.sh
@@ -11,6 +11,14 @@
 # run even if an earlier one fails.
 set -uo pipefail
 
+# Cap each individual check's stderr block before feeding it back to Claude.
+# A repo-wide lint can spew thousands of lines and blow out the context
+# window; 8K chars is enough to see the first dozen failures and bounded
+# against worst-case. Note: bash's ${#s} and ${s:0:N} count characters in a
+# UTF-8 locale, not bytes — fine for ~ASCII linter output, but the cap can
+# be larger than this in actual bytes if the output contains multibyte chars.
+MAX_OUTPUT_CHARS=8192
+
 # Read stdin payload and check stop_hook_active
 INPUT=$(cat 2>/dev/null || echo '{}')
 if command -v jq >/dev/null 2>&1; then
@@ -39,6 +47,17 @@ fi
 
 errors=()
 
+# Truncate to MAX_OUTPUT_CHARS if longer; the suffix tells the agent the
+# full length so it knows there's more behind the cap.
+truncate_output() {
+  local s="$1" len=${#1}
+  if (( len > MAX_OUTPUT_CHARS )); then
+    s="${s:0:$MAX_OUTPUT_CHARS}"
+    s+=$'\n... (output truncated; full length: '"$len"' chars)'
+  fi
+  printf '%s' "$s"
+}
+
 run() {
   local label="$1"; shift
   local output rc cmd
@@ -48,19 +67,56 @@ run() {
     # printf '%q' shell-quotes each arg so space-containing args render
     # unambiguously in the error output.
     cmd=$(printf '%q ' "$@")
+    output=$(truncate_output "$output")
     errors+=("[$label] exit $rc: ${cmd% }"$'\n'"$output")
   fi
+}
+
+# Print working-tree paths matching any of the given space-separated
+# extensions, one per line. Scope is staged + unstaged + untracked, with
+# deletions excluded. Working tree (not main..HEAD) keeps the list bounded
+# regardless of branch age — long-lived branches were the original
+# context-blowout source.
+#
+# In a brand-new repo with no HEAD yet, `git diff HEAD` errors. Fall back
+# to "everything in the index plus untracked" so initial-commit work still
+# gets linted.
+changed_files() {
+  local pattern="${1// /|}"
+  if git rev-parse --verify HEAD >/dev/null 2>&1; then
+    {
+      git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null
+      git ls-files --others --exclude-standard 2>/dev/null
+    } | grep -E "\.($pattern)$" 2>/dev/null
+  else
+    {
+      git ls-files --cached 2>/dev/null
+      git ls-files --others --exclude-standard 2>/dev/null
+    } | grep -E "\.($pattern)$" 2>/dev/null
+  fi
+  return 0
 }
 
 # Project-local verify wins
 if [[ -x .claude/verify.sh ]]; then
   if ! output=$(.claude/verify.sh fast 2>&1); then
+    output=$(truncate_output "$output")
     errors+=("[project-verify-fast]"$'\n'"$output")
   fi
 else
-  # Auto-detect — FAST CHECKS ONLY
-  if [[ -f Gemfile ]]; then
-    [[ -f bin/rubocop ]] && run "rubocop" bin/rubocop --force-exclusion
+  # Auto-detect — FAST CHECKS ONLY, scoped to changed files where the linter
+  # accepts file-list args. Projects whose linters don't fit this shape
+  # (Biome, Oxlint, custom wrappers) should add a project-local
+  # .claude/verify.sh fast.
+
+  if [[ -f Gemfile && -f bin/rubocop ]]; then
+    files=()
+    while IFS= read -r f; do
+      [[ -n "$f" ]] && files+=("$f")
+    done < <(changed_files "rb")
+    if (( ${#files[@]} > 0 )); then
+      run "rubocop" bin/rubocop --force-exclusion "${files[@]}"
+    fi
   fi
 
   if [[ -f package.json ]]; then
@@ -70,12 +126,31 @@ else
     fi
     if [[ -n "$pm" ]]; then
       grep -q '"typecheck"' package.json && run "typecheck" $pm run typecheck
-      grep -q '"lint"'      package.json && run "lint"      $pm run lint
+    fi
+    # Call the ESLint binary directly so we can pass file args. `pnpm run
+    # lint` is unreliable here because lint scripts like `eslint .` ignore
+    # extra arguments and lint the whole repo anyway.
+    if [[ -x node_modules/.bin/eslint ]]; then
+      files=()
+      while IFS= read -r f; do
+        [[ -n "$f" ]] && files+=("$f")
+      done < <(changed_files "js jsx ts tsx mjs cjs")
+      if (( ${#files[@]} > 0 )); then
+        run "eslint" node_modules/.bin/eslint "${files[@]}"
+      fi
     fi
   fi
 
   if compgen -G "*.xcodeproj" >/dev/null || compgen -G "*.xcworkspace" >/dev/null || [[ -f Package.swift ]]; then
-    command -v swiftlint >/dev/null && run "swiftlint" swiftlint --quiet
+    if command -v swiftlint >/dev/null; then
+      files=()
+      while IFS= read -r f; do
+        [[ -n "$f" ]] && files+=("$f")
+      done < <(changed_files "swift")
+      if (( ${#files[@]} > 0 )); then
+        run "swiftlint" swiftlint --quiet "${files[@]}"
+      fi
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary

- The Stop hook (`apps/claude/hooks/verify.sh`) was running repo-wide lint commands on every "done" event. On long-lived branches that produced thousands of lines of stderr, which got fed straight back into Claude's context window and blew it out
- Auto-detected linters (rubocop, eslint, swiftlint) now run only against working-tree changes — staged + unstaged + untracked, deletions filtered out. `git diff --name-only --diff-filter=ACMR HEAD` ∪ `git ls-files --others --exclude-standard`. Initial-commit repos with no HEAD fall back to listing the index
- Each error block is truncated to `MAX_OUTPUT_CHARS=8192` with a length suffix, so no single check can dominate the context window even if scoping misses something
- `pnpm run typecheck` stays repo-wide (`tsc --noEmit` is project-wide by nature; output usually small)
- ESLint is called via `node_modules/.bin/eslint` directly so file-list args are honoured (lint scripts like `"lint": "eslint ."` ignore extra args). Projects using non-ESLint linters (Biome, Oxlint, custom wrappers) should add a project-local `.claude/verify.sh fast`

## Test plan

- [x] `~/.claude/hooks/smoke-test-hook.sh` — 24 assertions across 12 cases pass
- [x] Test 9 confirms a non-Ruby change in a Ruby project skips rubocop entirely (exit 0)
- [x] Test 10 confirms 50 KiB of synthetic project-verify output gets capped: total stderr 8411 chars
- [x] Test 11 confirms a mixed-extension change set passes only the matching files to rubocop (foo.rb yes, README.md no)
- [x] Test 12 confirms initial-commit (no HEAD) repos still lint staged files

🤖 Generated with [Claude Code](https://claude.com/claude-code)